### PR TITLE
Text Collection attribute type

### DIFF
--- a/src/AttributeType/TextCollectionType.php
+++ b/src/AttributeType/TextCollectionType.php
@@ -3,6 +3,7 @@
 namespace Pim\Bundle\ExtendedAttributeTypeBundle\AttributeType;
 
 use Pim\Bundle\CatalogBundle\AttributeType\AbstractAttributeType;
+use Pim\Component\Catalog\AttributeTypes;
 use Pim\Component\Catalog\Model\AttributeInterface;
 
 /**
@@ -14,6 +15,12 @@ use Pim\Component\Catalog\Model\AttributeInterface;
  */
 class TextCollectionType extends AbstractAttributeType
 {
+    /** @const string */
+    const TYPE_TEXT_COLLECTION = 'pim_extended_attribute_type_text_collection';
+
+    /** @var string */
+    protected $backendType = AttributeTypes::BACKEND_TYPE_VARCHAR;
+
     /**
      * {@inheritdoc}
      */
@@ -32,6 +39,6 @@ class TextCollectionType extends AbstractAttributeType
      */
     public function getName()
     {
-        return 'pim_extended_attribute_text_collection';
+        return self::TYPE_TEXT_COLLECTION;
     }
 }

--- a/src/AttributeType/TextCollectionType.php
+++ b/src/AttributeType/TextCollectionType.php
@@ -20,13 +20,6 @@ class TextCollectionType extends AbstractAttributeType
     protected function defineCustomAttributeProperties(AttributeInterface $attribute)
     {
         $properties = parent::defineCustomAttributeProperties($attribute);
-//        $properties['autoOptionSorting'] = [
-//            'name'      => 'autoOptionSorting',
-//            'fieldType' => 'hidden',
-//            'options'   => [
-//                'property_path' => 'properties[autoOptionSorting]',
-//            ],
-//        ];
 
         $properties['unique']['options']['disabled'] = true;
         $properties['unique']['options']['read_only'] = true;

--- a/src/AttributeType/TextCollectionType.php
+++ b/src/AttributeType/TextCollectionType.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Pim\Bundle\ExtendedAttributeTypeBundle\AttributeType;
+
+use Pim\Bundle\CatalogBundle\AttributeType\AbstractAttributeType;
+use Pim\Component\Catalog\Model\AttributeInterface;
+
+/**
+ * Text collection attribute type
+ *
+ * @author    JM Leroux <jean-marie.leroux@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class TextCollectionType extends AbstractAttributeType
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function defineCustomAttributeProperties(AttributeInterface $attribute)
+    {
+        $properties = parent::defineCustomAttributeProperties($attribute);
+//        $properties['autoOptionSorting'] = [
+//            'name'      => 'autoOptionSorting',
+//            'fieldType' => 'hidden',
+//            'options'   => [
+//                'property_path' => 'properties[autoOptionSorting]',
+//            ],
+//        ];
+
+        $properties['unique']['options']['disabled'] = true;
+        $properties['unique']['options']['read_only'] = true;
+
+        return $properties;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'pim_extended_attribute_text_collection';
+    }
+}

--- a/src/DataGrid/Extension/Formatter/Property/ProductValue/TextCollectionProperty.php
+++ b/src/DataGrid/Extension/Formatter/Property/ProductValue/TextCollectionProperty.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Pim\Bundle\ExtendedAttributeTypeBundle\DataGrid\Extension\Formatter\Property\ProductValue;
+
+use Akeneo\Component\Localization\Presenter\PresenterInterface;
+use Pim\Bundle\DataGridBundle\Extension\Formatter\Property\ProductValue\TwigProperty;
+use Symfony\Component\Translation\TranslatorInterface;
+
+/**
+ * Formatter for Text collection attribute type.
+ * Works with a twig template (Resources/views/Property/text_collection.html.twig).
+ *
+ * @author JM Leroux <jean-marie.leroux@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class TextCollectionProperty extends TwigProperty
+{
+    /** @var PresenterInterface */
+    protected $presenter;
+
+    /**
+     * @param \Twig_Environment   $environment
+     * @param TranslatorInterface $translator
+     * @param PresenterInterface  $presenter
+     */
+    public function __construct(
+        \Twig_Environment $environment,
+        TranslatorInterface $translator,
+        PresenterInterface $presenter
+    ) {
+        parent::__construct($environment);
+        $this->translator = $translator;
+        $this->presenter  = $presenter;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function convertValue($value)
+    {
+        $result = $this->getBackendData($value);
+
+        return $this->presenter->present($result, ['locale' => $this->translator->getLocale()]);
+    }
+}

--- a/src/DependencyInjection/PimExtendedAttributeTypeExtension.php
+++ b/src/DependencyInjection/PimExtendedAttributeTypeExtension.php
@@ -27,6 +27,7 @@ class PimExtendedAttributeTypeExtension extends Extension
         $loader->load('completeness.yml');
         $loader->load('form_types.yml');
         $loader->load('normalizers.yml');
+        $loader->load('denormalizers.yml');
         $loader->load('providers.yml');
         $loader->load('query_builders.yml');
         $loader->load('updaters.yml');

--- a/src/Localization/Presenter/TextCollectionPresenter.php
+++ b/src/Localization/Presenter/TextCollectionPresenter.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Pim\Bundle\ExtendedAttributeTypeBundle\Localization\Presenter;
+
+use Akeneo\Component\Localization\Presenter\PresenterInterface;
+use Pim\Bundle\ExtendedAttributeTypeBundle\AttributeType\TextCollectionType;
+
+/**
+ * Text collection presenter, able to render text collection data localized and readable for a human.
+ *
+ * @author JM Leroux <jean-marie.leroux@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class TextCollectionPresenter implements PresenterInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function present($value, array $options = [])
+    {
+        $values = explode(';', $value);
+
+        return sprintf('<ul><li>%s</li></ul>', implode('</li><li>', $values));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports($attributeTypeCode)
+    {
+        return TextCollectionType::TYPE_TEXT_COLLECTION === $attributeTypeCode;
+    }
+}

--- a/src/Provider/Field/RangeFieldProvider.php
+++ b/src/Provider/Field/RangeFieldProvider.php
@@ -13,7 +13,7 @@ use Pim\Component\Catalog\Model\AttributeInterface;
  *
  * @author Romain Monceau <romain@akeneo.com>
  */
-class FieldProvider implements FieldProviderInterface
+class RangeFieldProvider implements FieldProviderInterface
 {
     /** @var string[] */
     protected $fields = [

--- a/src/Provider/Field/TextCollectionProvider.php
+++ b/src/Provider/Field/TextCollectionProvider.php
@@ -7,23 +7,22 @@ use Pim\Bundle\EnrichBundle\Provider\Field\FieldProviderInterface;
 /**
  * CompositionProvider
  *
- * @author    Antoine Guigan <antoine@akeneo.com>
- * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
+ * @author JM Leroux <jean-marie.leroux@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
 class TextCollectionProvider implements FieldProviderInterface
 {
+    /**
+     * {@inheritdoc}
+     */
     public function getField($element)
     {
        return 'pim_extended_attribute_text_collection';
     }
 
     /**
-     * Does the Field provider support the element
-     *
-     * @param mixed $element
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function supports($element)
     {

--- a/src/Provider/Field/TextCollectionProvider.php
+++ b/src/Provider/Field/TextCollectionProvider.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Pim\Bundle\ExtendedAttributeTypeBundle\Provider\Field;
+
+use Pim\Bundle\EnrichBundle\Provider\Field\FieldProviderInterface;
+
+/**
+ * CompositionProvider
+ *
+ * @author    Antoine Guigan <antoine@akeneo.com>
+ * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class TextCollectionProvider implements FieldProviderInterface
+{
+    public function getField($element)
+    {
+       return 'pim_extended_attribute_text_collection';
+    }
+
+    /**
+     * Does the Field provider support the element
+     *
+     * @param mixed $element
+     *
+     * @return bool
+     */
+    public function supports($element)
+    {
+        return 'pim_extended_attribute_text_collection' === $element->getAttributeType();
+    }
+}

--- a/src/Provider/Field/TextCollectionProvider.php
+++ b/src/Provider/Field/TextCollectionProvider.php
@@ -3,9 +3,12 @@
 namespace Pim\Bundle\ExtendedAttributeTypeBundle\Provider\Field;
 
 use Pim\Bundle\EnrichBundle\Provider\Field\FieldProviderInterface;
+use Pim\Bundle\ExtendedAttributeTypeBundle\AttributeType\TextCollectionType;
 
 /**
- * CompositionProvider
+ * Field provider for the Text collection attribute type.
+ *
+ * Used in the attribute normalizer, during product normalization.
  *
  * @author JM Leroux <jean-marie.leroux@akeneo.com>
  * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
@@ -18,7 +21,7 @@ class TextCollectionProvider implements FieldProviderInterface
      */
     public function getField($element)
     {
-       return 'pim_extended_attribute_text_collection';
+       return 'pim_extended_attribute_type_text_collection';
     }
 
     /**
@@ -26,6 +29,6 @@ class TextCollectionProvider implements FieldProviderInterface
      */
     public function supports($element)
     {
-        return 'pim_extended_attribute_text_collection' === $element->getAttributeType();
+        return TextCollectionType::TYPE_TEXT_COLLECTION === $element->getAttributeType();
     }
 }

--- a/src/Resources/config/array_converters.yml
+++ b/src/Resources/config/array_converters.yml
@@ -23,7 +23,7 @@ services:
         class: '%pim_connector.array_converter.standard_to_flat.product.value_converter.text.class%'
         arguments:
             - '@pim_connector.array_converter.flat_to_standard.product.attribute_columns_resolver'
-            - ['pim_extended_attribute_text_collection']
+            - ['pim_extended_attribute_type_text_collection']
         tags:
             - { name: 'pim_connector.array_converter.standard_to_flat.product.value_converter' }
 
@@ -31,7 +31,7 @@ services:
         class: '%pim_connector.array_converter.flat_to_standard.product.value_converter.text.class%'
         parent: pim_connector.array_converter.flat_to_standard.product.value_converter.abstract
         arguments:
-            - ['pim_extended_attribute_text_collection']
+            - ['pim_extended_attribute_type_text_collection']
         tags:
             - { name: 'pim_connector.array_converter.flat_to_standard.product.value_converter' }
 

--- a/src/Resources/config/array_converters.yml
+++ b/src/Resources/config/array_converters.yml
@@ -18,3 +18,20 @@ services:
             - '@pim_connector.array_converter.flat_to_standard.product.attribute_columns_resolver'
         tags:
             - { name: 'pim_connector.array_converter.standard_to_flat.product.value_converter' }
+
+    pim_extended_attribute_type.array_converter.standard_to_flat.product.value_converter.text_collection:
+        class: '%pim_connector.array_converter.standard_to_flat.product.value_converter.text.class%'
+        arguments:
+            - '@pim_connector.array_converter.flat_to_standard.product.attribute_columns_resolver'
+            - ['pim_extended_attribute_text_collection']
+        tags:
+            - { name: 'pim_connector.array_converter.standard_to_flat.product.value_converter' }
+
+    pim_extended_attribute_type.array_converter.flat_to_standard.product.value_converter.text_collection:
+        class: '%pim_connector.array_converter.flat_to_standard.product.value_converter.text.class%'
+        parent: pim_connector.array_converter.flat_to_standard.product.value_converter.abstract
+        arguments:
+            - ['pim_extended_attribute_text_collection']
+        tags:
+            - { name: 'pim_connector.array_converter.flat_to_standard.product.value_converter' }
+

--- a/src/Resources/config/attribute_icons.yml
+++ b/src/Resources/config/attribute_icons.yml
@@ -1,3 +1,4 @@
 parameters:
     pim_extended_attribute_type.attribute_icons:
         pim_extended_attribute_type_range: resize-horizontal
+        pim_extended_attribute_type_text_collection: book

--- a/src/Resources/config/attribute_types.yml
+++ b/src/Resources/config/attribute_types.yml
@@ -22,18 +22,3 @@ services:
             - '@pim_catalog.validator.constraint_guesser.chained_attribute'
         tags:
             - { name: pim_catalog.attribute_type, alias: pim_extended_attribute_type_text_collection }
-
-    pim_extended_attribute_type.validator.constraint_guesser.text_collection:
-        public: false
-        class: '%pim_extended_attribute_type.validator.constraint_guesser.text_collection.class%'
-        tags:
-            - { name: pim_catalog.constraint_guesser.attribute }
-
-    pim_extended_attribute_type.doctrine.query.filter.text_collection:
-        class: '%pim_catalog.doctrine.query.filter.string.class%'
-        arguments:
-            - '@pim_catalog.validator.helper.attribute'
-            - ['pim_extended_attribute_text_collection']
-            - ['CONTAINS', 'DOES NOT CONTAIN']
-        tags:
-            - { name: 'pim_catalog.doctrine.query.filter', priority: 30 }

--- a/src/Resources/config/attribute_types.yml
+++ b/src/Resources/config/attribute_types.yml
@@ -1,6 +1,17 @@
 parameters:
     pim_extended_attribute_type.attribute_type.range.class: Pim\Bundle\ExtendedAttributeTypeBundle\AttributeType\RangeType
 
+    pim_datagrid.product.attribute_type.pim_extended_attribute_text_collection:
+        column:
+            type:        product_value_field
+            selector:    product_value_base
+        filter:
+            type:        product_value_string
+            ftype:       string
+        sorter:          product_value
+
+    pim_extended_attribute_type.validator.constraint_guesser.text_collection.class: Pim\Bundle\ExtendedAttributeTypeBundle\Validator\ConstraintGuesser\TextCollectionGuesser
+
 services:
     pim_extended_attribute_type.attribute_type.range:
         class: '%pim_extended_attribute_type.attribute_type.range.class%'
@@ -11,3 +22,26 @@ services:
         tags:
             - { name: pim_catalog.attribute_type, alias: pim_extended_attribute_type_range, entity: '%pim_catalog.entity.product.class%' }
 
+    pim_extended_attribute_type.attribute_type.text_collection:
+        class: Pim\Bundle\ExtendedAttributeTypeBundle\AttributeType\TextCollectionType
+        arguments:
+            - text
+            - textarea
+            - '@pim_catalog.validator.constraint_guesser.chained_attribute'
+        tags:
+            - { name: pim_catalog.attribute_type, alias: pim_extended_attribute_text_collection }
+
+    pim_extended_attribute_type.validator.constraint_guesser.text_collection:
+        public: false
+        class: '%pim_extended_attribute_type.validator.constraint_guesser.text_collection.class%'
+        tags:
+            - { name: pim_catalog.constraint_guesser.attribute }
+
+    pim_catalog.doctrine.query.filter.text_collection:
+        class: '%pim_catalog.doctrine.query.filter.string.class%'
+        arguments:
+            - '@pim_catalog.validator.helper.attribute'
+            - ['pim_extended_attribute_text_collection']
+            - ['STARTS WITH', 'ENDS WITH', 'CONTAINS', 'DOES NOT CONTAIN']
+        tags:
+            - { name: 'pim_catalog.doctrine.query.filter', priority: 30 }

--- a/src/Resources/config/attribute_types.yml
+++ b/src/Resources/config/attribute_types.yml
@@ -1,5 +1,6 @@
 parameters:
     pim_extended_attribute_type.attribute_type.range.class: Pim\Bundle\ExtendedAttributeTypeBundle\AttributeType\RangeType
+    pim_extended_attribute_type.attribute_type.text_collection.class: Pim\Bundle\ExtendedAttributeTypeBundle\AttributeType\TextCollectionType
 
     pim_datagrid.product.attribute_type.pim_extended_attribute_text_collection:
         column:
@@ -23,7 +24,7 @@ services:
             - { name: pim_catalog.attribute_type, alias: pim_extended_attribute_type_range, entity: '%pim_catalog.entity.product.class%' }
 
     pim_extended_attribute_type.attribute_type.text_collection:
-        class: Pim\Bundle\ExtendedAttributeTypeBundle\AttributeType\TextCollectionType
+        class: '%pim_extended_attribute_type.attribute_type.text_collection.class%'
         arguments:
             - text
             - textarea
@@ -37,7 +38,7 @@ services:
         tags:
             - { name: pim_catalog.constraint_guesser.attribute }
 
-    pim_catalog.doctrine.query.filter.text_collection:
+    pim_extended_attribute_type.doctrine.query.filter.text_collection:
         class: '%pim_catalog.doctrine.query.filter.string.class%'
         arguments:
             - '@pim_catalog.validator.helper.attribute'

--- a/src/Resources/config/attribute_types.yml
+++ b/src/Resources/config/attribute_types.yml
@@ -2,15 +2,6 @@ parameters:
     pim_extended_attribute_type.attribute_type.range.class: Pim\Bundle\ExtendedAttributeTypeBundle\AttributeType\RangeType
     pim_extended_attribute_type.attribute_type.text_collection.class: Pim\Bundle\ExtendedAttributeTypeBundle\AttributeType\TextCollectionType
 
-    pim_datagrid.product.attribute_type.pim_extended_attribute_text_collection:
-        column:
-            type:        product_value_field
-            selector:    product_value_base
-        filter:
-            type:        product_value_string
-            ftype:       string
-        sorter:          product_value
-
     pim_extended_attribute_type.validator.constraint_guesser.text_collection.class: Pim\Bundle\ExtendedAttributeTypeBundle\Validator\ConstraintGuesser\TextCollectionGuesser
 
 services:
@@ -30,7 +21,7 @@ services:
             - textarea
             - '@pim_catalog.validator.constraint_guesser.chained_attribute'
         tags:
-            - { name: pim_catalog.attribute_type, alias: pim_extended_attribute_text_collection }
+            - { name: pim_catalog.attribute_type, alias: pim_extended_attribute_type_text_collection }
 
     pim_extended_attribute_type.validator.constraint_guesser.text_collection:
         public: false
@@ -43,6 +34,6 @@ services:
         arguments:
             - '@pim_catalog.validator.helper.attribute'
             - ['pim_extended_attribute_text_collection']
-            - ['STARTS WITH', 'ENDS WITH', 'CONTAINS', 'DOES NOT CONTAIN']
+            - ['CONTAINS', 'DOES NOT CONTAIN']
         tags:
             - { name: 'pim_catalog.doctrine.query.filter', priority: 30 }

--- a/src/Resources/config/comparators.yml
+++ b/src/Resources/config/comparators.yml
@@ -10,6 +10,6 @@ services:
     pim_extended_attribute_type.comparator.attribute.scalar:
         class: '%pim_catalog.comparator.attribute.scalar.class%'
         arguments:
-            - [ 'pim_extended_attribute_text_collection']
+            - [ 'pim_extended_attribute_type_text_collection']
         tags:
             - { name: pim_catalog.attribute.comparator, priority: -128 }

--- a/src/Resources/config/comparators.yml
+++ b/src/Resources/config/comparators.yml
@@ -6,3 +6,10 @@ services:
         class: '%pim_extended_attribute_type.comparator.product_range.class%'
         tags:
             - { name: pim_catalog.attribute.comparator }
+
+    pim_extended_attribute_type.comparator.attribute.scalar:
+        class: '%pim_catalog.comparator.attribute.scalar.class%'
+        arguments:
+            - [ 'pim_extended_attribute_text_collection']
+        tags:
+            - { name: pim_catalog.attribute.comparator, priority: -128 }

--- a/src/Resources/config/datagrid/attribute_types.yml
+++ b/src/Resources/config/datagrid/attribute_types.yml
@@ -4,7 +4,6 @@ parameters:
             type:          product_value_range
             selector:      product_value_range
             frontend_type: html
-            template:      PimExtendedAttributeTypeBundle:Property:range.html.twig
         filter:
             type:          product_value_range
             ftype:         range
@@ -13,3 +12,18 @@ parameters:
                     attr:
                         empty_choice: true
         sorter:            ~
+
+    pim_datagrid.product.attribute_type.pim_extended_attribute_type_text_collection:
+        column:
+            type:          product_value_text_collection
+            selector:      product_value_base
+            frontend_type: html
+        filter:
+            type:          product_value_string
+            ftype:         string
+            options:
+                field_options:
+                    attr:
+                        empty_choice: true
+        sorter:            ~
+

--- a/src/Resources/config/datagrid/attribute_types.yml
+++ b/src/Resources/config/datagrid/attribute_types.yml
@@ -3,7 +3,6 @@ parameters:
         column:
             type:          product_value_range
             selector:      product_value_range
-            frontend_type: html
         filter:
             type:          product_value_range
             ftype:         range

--- a/src/Resources/config/datagrid/formatters.yml
+++ b/src/Resources/config/datagrid/formatters.yml
@@ -1,5 +1,6 @@
 parameters:
     pim_extended_attribute_type.datagrid.extension.formatter.property.product_value.range.class: Pim\Bundle\ExtendedAttributeTypeBundle\DataGrid\Extension\Formatter\Property\ProductValue\RangeProperty
+    pim_extended_attribute_type.datagrid.extension.formatter.property.product_value.text_collection.class: Pim\Bundle\ExtendedAttributeTypeBundle\DataGrid\Extension\Formatter\Property\ProductValue\TextCollectionProperty
 
 services:
     pim_extended_attribute_type.datagrid.extension.formatter.property.product_value.range:
@@ -10,3 +11,12 @@ services:
             - '@pim_extended_attribute_type.localization.presenter.range'
         tags:
             - { name: oro_datagrid.extension.formatter.property, type: product_value_range }
+
+    pim_extended_attribute_type.datagrid.extension.formatter.property.product_value.text_collection:
+        class: '%pim_extended_attribute_type.datagrid.extension.formatter.property.product_value.text_collection.class%'
+        arguments:
+            - '@twig'
+            - '@translator'
+            - '@pim_extended_attribute_type.localization.presenter.text_collection'
+        tags:
+            - { name: oro_datagrid.extension.formatter.property, type: product_value_text_collection }

--- a/src/Resources/config/denormalizers.yml
+++ b/src/Resources/config/denormalizers.yml
@@ -1,0 +1,7 @@
+services:
+    pim_extended_attribute_type.denormalizer.base_value:
+        class: '%pim_serializer.denormalizer.flat.base_value.class%'
+        arguments:
+            - ['pim_extended_attribute_text_collection']
+        tags:
+            - { name: pimee_versioning.serializer.normalizer, priority: 90 }

--- a/src/Resources/config/denormalizers.yml
+++ b/src/Resources/config/denormalizers.yml
@@ -4,4 +4,4 @@ services:
         arguments:
             - ['pim_extended_attribute_text_collection']
         tags:
-            - { name: pimee_versioning.serializer.normalizer, priority: 90 }
+            - { name: pim_versioning.serializer.normalizer, priority: 90 }

--- a/src/Resources/config/denormalizers.yml
+++ b/src/Resources/config/denormalizers.yml
@@ -2,6 +2,6 @@ services:
     pim_extended_attribute_type.denormalizer.text_collection:
         class: '%pim_serializer.denormalizer.flat.base_value.class%'
         arguments:
-            - ['pim_extended_attribute_text_collection']
+            - ['pim_extended_attribute_type_text_collection']
         tags:
             - { name: pim_versioning.serializer.normalizer, priority: 90 }

--- a/src/Resources/config/denormalizers.yml
+++ b/src/Resources/config/denormalizers.yml
@@ -1,5 +1,5 @@
 services:
-    pim_extended_attribute_type.denormalizer.base_value:
+    pim_extended_attribute_type.denormalizer.text_collection:
         class: '%pim_serializer.denormalizer.flat.base_value.class%'
         arguments:
             - ['pim_extended_attribute_text_collection']

--- a/src/Resources/config/form_extensions.yml
+++ b/src/Resources/config/form_extensions.yml
@@ -1,3 +1,3 @@
 attribute_fields:
     pim-extended-attribute-type-range-field: pim-extended-attribute-type/range-field
-    pim_extended_attribute_text_collection: pim-extended-attribute-type/text-collection-field
+    pim_extended_attribute_type_text_collection: pim-extended-attribute-type/text-collection-field

--- a/src/Resources/config/form_extensions.yml
+++ b/src/Resources/config/form_extensions.yml
@@ -1,2 +1,3 @@
 attribute_fields:
     pim-extended-attribute-type-range-field: pim-extended-attribute-type/range-field
+    pim_extended_attribute_text_collection: pim-extended-attribute-type/text-collection-field

--- a/src/Resources/config/localization/presenters.yml
+++ b/src/Resources/config/localization/presenters.yml
@@ -1,5 +1,6 @@
 parameters:
     pim_extended_attribute_type.localization.presenter.range.class: Pim\Bundle\ExtendedAttributeTypeBundle\Localization\Presenter\RangePresenter
+    pim_extended_attribute_type.localization.presenter.text_collection.class: Pim\Bundle\ExtendedAttributeTypeBundle\Localization\Presenter\TextCollectionPresenter
 
 services:
     pim_extended_attribute_type.localization.presenter.range:
@@ -7,5 +8,10 @@ services:
         arguments:
             - '@pim_catalog.localization.factory.number'
             - ['pim_extended_attribute_type_range']
+        tags:
+            - { name: pim_catalog.localization.presenter, type: 'product_value' }
+
+    pim_extended_attribute_type.localization.presenter.text_collection:
+        class: '%pim_extended_attribute_type.localization.presenter.text_collection.class%'
         tags:
             - { name: pim_catalog.localization.presenter, type: 'product_value' }

--- a/src/Resources/config/providers.yml
+++ b/src/Resources/config/providers.yml
@@ -1,5 +1,6 @@
 parameters:
-    pim_extended_attribute_type.provider.field.range.class: Pim\Bundle\ExtendedAttributeTypeBundle\Provider\Field\FieldProvider
+    pim_extended_attribute_type.provider.field.range.class: Pim\Bundle\ExtendedAttributeTypeBundle\Provider\Field\RangeFieldProvider
+    pim_extended_attribute_type.provider.field.text_collection.class: Pim\Bundle\ExtendedAttributeTypeBundle\Provider\Field\TextCollectionProvider
     pim_extended_attribute_type.provider.empty_value.range.class: Pim\Bundle\ExtendedAttributeTypeBundle\Provider\EmptyValue\RangeEmptyValueProvider
 
 services:
@@ -12,3 +13,8 @@ services:
         class: '%pim_extended_attribute_type.provider.empty_value.range.class%'
         tags:
             - { name: pim_enrich.provider.empty_value, priority: 90 }
+
+    pim_extended_attribute_type.provider.field.composition:
+        class: '%pim_extended_attribute_type.provider.field.text_collection.class%'
+        tags:
+            - { name: pim_enrich.provider.field, priority: 100 }

--- a/src/Resources/config/providers.yml
+++ b/src/Resources/config/providers.yml
@@ -14,7 +14,7 @@ services:
         tags:
             - { name: pim_enrich.provider.empty_value, priority: 90 }
 
-    pim_extended_attribute_type.provider.field.composition:
+    pim_extended_attribute_type.provider.field.text_collection:
         class: '%pim_extended_attribute_type.provider.field.text_collection.class%'
         tags:
             - { name: pim_enrich.provider.field, priority: 100 }

--- a/src/Resources/config/query_builders.yml
+++ b/src/Resources/config/query_builders.yml
@@ -6,3 +6,12 @@ services:
             - ['EMPTY']
         tags:
             - { name: 'pim_catalog.doctrine.query.filter', priority: 30 }
+
+    pim_extended_attribute_type.doctrine.query.filter.text_collection:
+        class: '%pim_catalog.doctrine.query.filter.string.class%'
+        arguments:
+            - '@pim_catalog.validator.helper.attribute'
+            - ['pim_extended_attribute_text_collection']
+            - ['CONTAINS', 'DOES NOT CONTAIN']
+        tags:
+            - { name: 'pim_catalog.doctrine.query.filter', priority: 30 }

--- a/src/Resources/config/requirejs.yml
+++ b/src/Resources/config/requirejs.yml
@@ -5,10 +5,9 @@ config:
 
         # Form
         pim-extended-attribute-type/range-field: pimextendedattributetype/js/product/field/range-field
+        pim-extended-attribute-type/text-collection-field: pimextendedattributetype/js/product/field/text-collection-field
 
         # Template
         pim-extended-attribute-type/templates/product/field/range: pimextendedattributetype/templates/product/field/range.html
-
-        pim-extended-attribute-type/text-collection-field: pimextendedattributetype/js/product/field/text-collection-field
-        pim-extended-attribute-type/template/product/field/text-collection: pimextendedattributetype/templates/product/field/text-collection.html
-        pim-extended-attribute-type/template/product/field/text-collection-row: pimextendedattributetype/templates/product/field/text-collection-row.html
+        pim-extended-attribute-type/templates/product/field/text-collection: pimextendedattributetype/templates/product/field/text-collection.html
+        pim-extended-attribute-type/templates/product/field/text-collection-row: pimextendedattributetype/templates/product/field/text-collection-row.html

--- a/src/Resources/config/requirejs.yml
+++ b/src/Resources/config/requirejs.yml
@@ -8,3 +8,7 @@ config:
 
         # Template
         pim-extended-attribute-type/templates/product/field/range: pimextendedattributetype/templates/product/field/range.html
+
+        pim-extended-attribute-type/text-collection-field: pimextendedattributetype/js/product/field/text-collection-field
+        pim-extended-attribute-type/template/product/field/text-collection: pimextendedattributetype/templates/product/field/text-collection.html
+        pim-extended-attribute-type/template/product/field/text-collection-row: pimextendedattributetype/templates/product/field/text-collection-row.html

--- a/src/Resources/config/updaters.yml
+++ b/src/Resources/config/updaters.yml
@@ -19,6 +19,6 @@ services:
         class: '%pim_catalog.updater.setter.text_value.class%'
         parent: pim_catalog.updater.setter.abstract
         arguments:
-            - ['pim_extended_attribute_text_collection']
+            - ['pim_extended_attribute_type_text_collection']
         tags:
             - { name: 'pim_catalog.updater.setter' }

--- a/src/Resources/config/updaters.yml
+++ b/src/Resources/config/updaters.yml
@@ -14,3 +14,11 @@ services:
         parent: pim_catalog.updater.setter.abstract
         tags:
             - { name: 'pim_catalog.updater.setter' }
+
+    pim_extended_attribute_type.updater.setter.text_value:
+        class: '%pim_catalog.updater.setter.text_value.class%'
+        parent: pim_catalog.updater.setter.abstract
+        arguments:
+            - ['pim_extended_attribute_text_collection']
+        tags:
+            - { name: 'pim_catalog.updater.setter' }

--- a/src/Resources/config/validators.yml
+++ b/src/Resources/config/validators.yml
@@ -7,3 +7,9 @@ services:
         class: '%pim_extended_attribute_type.validator.constraint_guesser.range.class%'
         tags:
             - { name: pim_catalog.constraint_guesser.attribute }
+
+    pim_extended_attribute_type.validator.constraint_guesser.text_collection:
+        public: false
+        class: '%pim_extended_attribute_type.validator.constraint_guesser.text_collection.class%'
+        tags:
+            - { name: pim_catalog.constraint_guesser.attribute }

--- a/src/Resources/public/js/product/field/range-field.js
+++ b/src/Resources/public/js/product/field/range-field.js
@@ -9,7 +9,7 @@ define (
     [
         'pim/field',
         'underscore',
-        'text!pimextendedattributetype/templates/product/field/range'
+        'text!pim-extended-attribute-type/templates/product/field/range'
     ], function (
         Field,
         _,

--- a/src/Resources/public/js/product/field/text-collection-field.js
+++ b/src/Resources/public/js/product/field/text-collection-field.js
@@ -1,0 +1,101 @@
+'use strict';
+/**
+ * Text collection field
+ *
+ * @author    JM Leroux <jean-marie.leroux@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+define(
+    [
+        'pim/field',
+        'underscore',
+        'jquery',
+        'text!pim-extended-attribute-type/template/product/field/text-collection',
+        'text!pim-extended-attribute-type/template/product/field/text-collection-row'
+    ],
+    function (Field,
+              _,
+              $,
+              fieldTemplate, rowTemplate) {
+        return Field.extend({
+            fieldTemplate: _.template(fieldTemplate),
+            rowTemplate: _.template(rowTemplate),
+            rowPrototype: null,
+            rawData: null,
+            renderInput: function (context) {
+                this.rowPrototype = this.rowTemplate(context);
+                this.rawData = context.value.data;
+                return this.fieldTemplate(context);
+            },
+            postRender: function () {
+                var $fieldInput = this.$('.field-input:first');
+                var $tableBody = $fieldInput.find('tbody');
+                var self = this;
+
+                if (null !== this.rawData) {
+                    this.rawData.split(';').forEach(function (value) {
+                        var $row = $(this.rowPrototype);
+                        var $field = $row.find('.pim-extended-attribute-text-collection-field').first();
+                        $field.val(value);
+                        $tableBody.append($row);
+                    }.bind(this));
+                }
+
+                $fieldInput.find(".pim-extended-attribute-text-collection-add").click(function () {
+                    var $newRow = $(this.rowPrototype);
+                    $tableBody.append($newRow);
+                    this.updateRawData();
+                }.bind(this));
+
+                $tableBody
+                    .on("change", ".pim-extended-attribute-text-collection-field", this.updateRawData.bind(this))
+                    .on('click', 'button', function () {
+                        $(this).closest("tr").remove();
+                        self.updateRawData();
+
+                        return false;
+                    })
+                    .sortable({
+                        axis: "y",
+                        cursor: "move",
+                        handle: ".icon-reorder",
+                        update: this.updateRawData.bind(this),
+                        start: function (e, ui) {
+                            ui.placeholder.height(ui.helper.outerHeight());
+                        },
+                        tolerance: "pointer",
+                        helper: function (e, tr) {
+                            var originals = tr.children();
+                            var helper = tr.clone();
+                            helper.children().each(function (index) {
+                                $(this).width(originals.eq(index).outerWidth());
+                            });
+                            return helper;
+                        },
+                        forcePlaceholderSize: true
+                    });
+            },
+            updateRawData: function () {
+                var value = [];
+                this.$('.field-input:first .pim-extended-attribute-text-collection-values tbody tr').each(function () {
+                    var $row = $(this);
+                    var row = [
+                        $row.find(".pim-extended-attribute-text-collection-value").val()
+                    ];
+                    value.push(row.join(':'));
+                });
+                this.rawData = value.join(';');
+                this.updateModel();
+            },
+            updateModel: function () {
+                var data = this.rawData;
+                data = '' === data ? this.attribute.empty_value : data;
+                this.setCurrentValue(data);
+            },
+            setFocus: function () {
+                this.$('.field-input:first textarea').focus();
+            }
+        });
+    }
+);

--- a/src/Resources/public/js/product/field/text-collection-field.js
+++ b/src/Resources/public/js/product/field/text-collection-field.js
@@ -11,8 +11,8 @@ define(
         'pim/field',
         'underscore',
         'jquery',
-        'text!pim-extended-attribute-type/template/product/field/text-collection',
-        'text!pim-extended-attribute-type/template/product/field/text-collection-row'
+        'text!pim-extended-attribute-type/templates/product/field/text-collection',
+        'text!pim-extended-attribute-type/templates/product/field/text-collection-row'
     ],
     function (Field,
               _,

--- a/src/Resources/public/templates/product/field/text-collection-row.html
+++ b/src/Resources/public/templates/product/field/text-collection-row.html
@@ -1,0 +1,14 @@
+<tr>
+    <% if (editMode !== 'view') { %>
+    <td class="handle"><i class="icon-reorder"></i></td>
+    <% } %>
+    <td><input type="text" class="pim-extended-attribute-text-collection-field pim-extended-attribute-text-collection-value"
+        <%= editMode === 'view' ? 'disabled' : '' %>
+        />
+    </td>
+    <% if (editMode !== 'view') { %>
+    <td>
+        <button class="btn btn-small action-delete-inline" type="button"><i class="icon-remove"></i></button>
+    </td>
+    <% } %>
+</tr>

--- a/src/Resources/public/templates/product/field/text-collection.html
+++ b/src/Resources/public/templates/product/field/text-collection.html
@@ -1,0 +1,9 @@
+<div class="asset-gallery">
+    <table class="pim-extended-attribute-text-collection-values" style="width: 100%">
+        <tbody>
+        </tbody>
+    </table>
+    <% if (editMode !== 'view') { %>
+    <button class="btn btn-success pull-right pim-extended-attribute-text-collection-add">Add item</button>
+    <% } %>
+</div>

--- a/src/Resources/translations/messages.en.yml
+++ b/src/Resources/translations/messages.en.yml
@@ -1,1 +1,2 @@
 pim_extended_attribute_type_range: Range
+pim_extended_attribute_type_text_collection: Text Collection

--- a/src/Validator/ConstraintGuesser/TextCollectionGuesser.php
+++ b/src/Validator/ConstraintGuesser/TextCollectionGuesser.php
@@ -2,11 +2,12 @@
 
 namespace Pim\Bundle\ExtendedAttributeTypeBundle\Validator\ConstraintGuesser;
 
+use Pim\Bundle\ExtendedAttributeTypeBundle\AttributeType\TextCollectionType;
 use Pim\Component\Catalog\Validator\ConstraintGuesserInterface;
 use Pim\Component\Catalog\Model\AttributeInterface;
 
 /**
- * Composition constraint guesser
+ * Validation guesser for the text collection attribute type.
  *
  * @author JM Leroux <jean-marie.leroux@akeneo.com>
  * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
@@ -22,7 +23,7 @@ class TextCollectionGuesser implements ConstraintGuesserInterface
         return in_array(
             $attribute->getAttributeType(),
             [
-                'pim_extended_attribute_text_collection',
+                TextCollectionType::TYPE_TEXT_COLLECTION,
             ]
         );
     }

--- a/src/Validator/ConstraintGuesser/TextCollectionGuesser.php
+++ b/src/Validator/ConstraintGuesser/TextCollectionGuesser.php
@@ -8,8 +8,9 @@ use Pim\Component\Catalog\Model\AttributeInterface;
 /**
  * Composition constraint guesser
  *
- * @author    Marie Minasyan <marie.minasyan@akeneo.com>
+ * @author JM Leroux <jean-marie.leroux@akeneo.com>
  * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
 class TextCollectionGuesser implements ConstraintGuesserInterface
 {

--- a/src/Validator/ConstraintGuesser/TextCollectionGuesser.php
+++ b/src/Validator/ConstraintGuesser/TextCollectionGuesser.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Pim\Bundle\ExtendedAttributeTypeBundle\Validator\ConstraintGuesser;
+
+use Pim\Component\Catalog\Validator\ConstraintGuesserInterface;
+use Pim\Component\Catalog\Model\AttributeInterface;
+
+/**
+ * Composition constraint guesser
+ *
+ * @author    Marie Minasyan <marie.minasyan@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ */
+class TextCollectionGuesser implements ConstraintGuesserInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function supportAttribute(AttributeInterface $attribute)
+    {
+        return in_array(
+            $attribute->getAttributeType(),
+            [
+                'pim_extended_attribute_text_collection',
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function guessConstraints(AttributeInterface $attribute)
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
This PR add the Text Collection attribute type.
A Text Collection is used to store multiple texts in an ordered list.

**Example in the PEF:**

<img src="https://cloud.githubusercontent.com/assets/1516770/21177216/78fc7f8a-c1ea-11e6-8e06-962856adef77.png" width="500">

**Example in the GRID:**

<img src="https://cloud.githubusercontent.com/assets/1516770/21177219/7d6638fe-c1ea-11e6-9b96-5a44d1bff496.png" width="500">

