### PR TITLE
Elasticsearch AttributeFilter for TextCollectionValue

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -118,9 +118,8 @@ def runIntegrationTestCe(version) {
 
                 sh "cat app/AppKernel.php"
 
-
                 sh "rm ./var/cache/* -rf"
-                sh "./bin/console --env=test pim:install --force"
+                sh "./bin/console --env=test pim:installer:db"
                 sh "mkdir -p app/build/logs/"
                 sh "./vendor/bin/phpunit -c app/ --log-junit app/build/logs/phpunit.xml  vendor/akeneo/extended-attribute-type/Tests"
         } finally {
@@ -150,7 +149,7 @@ def runIntegrationTestEe(version) {
                 sh "sed -i 's/database_host:.*/database_host: 127.0.0.1/' app/config/parameters_test.yml"
 
                 sh "rm ./var/cache/* -rf"
-                sh "./bin/console --env=test pim:install --force"
+                sh "./bin/console --env=test pim:installer:db"
                 sh "mkdir -p app/build/logs/"
                 sh "./vendor/bin/phpunit -c app/ --log-junit app/build/logs/phpunit.xml  vendor/akeneo/extended-attribute-type/Tests"
         } finally {
@@ -185,7 +184,7 @@ def podIntegration(phpVersion, body) {
                 envVars: [
                     envVar(key: "ES_JAVA_OPTS", value: "-Xms256m -Xmx512m"),
                     envVar(key: "FORCE", value: "true"),
-                    ]
+                ]
             ),
             containerTemplate(name: "mysql", image: "mysql:5.7", resourceRequestCpu: '100m', resourceRequestMemory: '200Mi',
                 envVars: [

--- a/README.md
+++ b/README.md
@@ -29,6 +29,24 @@ $bundles = [
 ];
 ```
 
+You will also have to register the new Elasticsearch configuration files; in `app/config/pim_parameters.yml`, edit the 
+`elasticsearch_index_configuration_files` parameter and add the following values:
+
+```yaml
+elasticsearch_index_configuration_files:
+    - '%kernel.root_dir%/../vendor/akeneo/pim-community-dev/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml'
+    - '%kernel.root_dir%/../vendor/akeneo/extended-attribute-type/src/Resources/config/elasticsearch/index_configuration.yml'
+```
+
+For the Enterprise edition, there is another file to register:
+```yaml
+elasticsearch_index_configuration_files:
+    - '%kernel.root_dir%/../vendor/akeneo/pim-community-dev/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml'
+    - '%kernel.root_dir%/../vendor/akeneo/pim-enterprise-dev/src/PimEnterprise/Bundle/WorkflowBundle/Resources/elasticsearch/index_configuration.yml'
+    - '%kernel.root_dir%/../vendor/akeneo/extended-attribute-type/src/Resources/config/elasticsearch/index_configuration.yml'
+    - '%kernel.root_dir%/../vendor/akeneo/extended-attribute-type/src/Resources/config/elasticsearch/index_configuration_ee.yml'    
+```
+
 ## Contributing
 
 If you want to contribute to this open-source project,

--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@ elasticsearch_index_configuration_files:
     - '%kernel.root_dir%/../vendor/akeneo/extended-attribute-type/src/Resources/config/elasticsearch/index_configuration_ee.yml'    
 ```
 
+If this is a fresh install, you can then proceed with a standard installation.
+
+From an existing PIM, on the other hand, you will have to re-create your elasticsearch indexes:
+```
+    php bin/console cache:clear --no-warmup --env=prod
+    php bin/console akeneo:elasticsearch:reset-indexes --env=prod
+    php bin/console pim:product-model:index --all --env=prod
+    php bin/console pim:product:index --all --env=prod
+```
+
 ## Contributing
 
 If you want to contribute to this open-source project,

--- a/Tests/Elasticsearch/TextCollectionFilterTest.php
+++ b/Tests/Elasticsearch/TextCollectionFilterTest.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace Tests\Elasticsearch;
+
+use Akeneo\Test\IntegrationTestsBundle\Security\SystemUserAuthenticator;
+use Pim\Bundle\ExtendedAttributeTypeBundle\AttributeType\ExtendedAttributeTypes;
+use Pim\Bundle\ExtendedAttributeTypeBundle\Tests\AppKernelTest;
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Query\Filter\Operators;
+use Pim\Component\Catalog\Query\ProductQueryBuilderFactoryInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * @author    Mathias METAYER <mathias.metayer@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class TextCollectionFilterTest extends KernelTestCase
+{
+    /** @var ContainerInterface */
+    protected $container;
+
+    /** @var ProductQueryBuilderFactoryInterface */
+    private $pqbFactory;
+
+    public function setUp()
+    {
+        static::bootKernel(['debug' => false]);
+
+        $this->container = static::$kernel->getContainer();
+        $authenticator = new SystemUserAuthenticator($this->container);
+        $authenticator->createSystemUser();
+
+        $this->pqbFactory = $this->container->get('pim_catalog.query.product_query_builder_factory');
+        $this->resetDB();
+        $this->loadData();
+    }
+
+    public function testTextCollectionValueContainsItem()
+    {
+        $this->createProduct('first_sku', ['foo', 'bar', 'baz']);
+        $this->createProduct('second_sku', ['bar', 'test']);
+        $this->createProduct('third_sku', ['http://foo/bar/baz', 'foo']);
+
+        $pqb = $this->pqbFactory->create();
+        $pqb->addFilter('my_images', Operators::CONTAINS, 'bar');
+        $products = $pqb->execute();
+
+        $this->assertCount(2, $products);
+        foreach ($products as $product) {
+            $this->assertContains($product->getIdentifier(), ['first_sku', 'second_sku']);
+        }
+
+        $pqb = $this->pqbFactory->create();
+        $pqb->addFilter('my_images', Operators::CONTAINS, 'http://foo/bar/baz');
+        $products = $pqb->execute();
+
+        $this->assertCount(1, $products);
+        $this->assertEquals('third_sku', $products->current()->getIdentifier());
+    }
+
+    public function testTextCollectionValueDoesNotContainItem()
+    {
+        $this->createProduct('first_sku', ['foo', 'bar', 'baz']);
+        $this->createProduct('second_sku', ['http://foo/bar/baz', 'foo']);
+
+        $pqb = $this->pqbFactory->create();
+        $pqb->addFilter('my_images', Operators::DOES_NOT_CONTAIN, 'foo');
+        $products = $pqb->execute();
+        $this->assertCount(0, $products);
+
+        $pqb = $this->pqbFactory->create();
+        $pqb->addFilter('my_images', Operators::DOES_NOT_CONTAIN, 'http://foo/bar/baz');
+        $products = $pqb->execute();
+        $this->assertCount(1, $products);
+        $product = $products->current();
+        $this->assertEquals('first_sku', $product->getIdentifier());
+
+        $pqb = $this->pqbFactory->create();
+        $pqb->addFilter('my_images', Operators::DOES_NOT_CONTAIN, 'http://foo/bar');
+        $products = $pqb->execute();
+        $this->assertCount(2, $products);
+    }
+
+    public function testEmptyAndNotEmptyFilters()
+    {
+        $this->createProduct('empty_sku');
+        $this->createProduct('not_empty_sku', ['foo']);
+
+        $pqb = $this->pqbFactory->create();
+        $pqb->addFilter('my_images', Operators::IS_EMPTY, null);
+        $products = $pqb->execute();
+
+        $this->assertCount(1, $products);
+        /** @var ProductInterface $product */
+        $product = $products->current();
+        $this->assertEquals('empty_sku', $product->getIdentifier());
+
+        $pqb = $this->pqbFactory->create();
+        $pqb->addFilter('my_images', Operators::IS_NOT_EMPTY, null);
+        $products = $pqb->execute();
+
+        $this->assertCount(1, $products);
+        /** @var ProductInterface $product */
+        $product = $products->current();
+        $this->assertEquals('not_empty_sku', $product->getIdentifier());
+    }
+
+    /**
+     * @param array
+     */
+    protected function loadData()
+    {
+        $attributeGroupRepo = $this->container->get('pim_catalog.repository.attribute_group');
+        $attributeGroup = $attributeGroupRepo->findOneByIdentifier('other');
+        if (null === $attributeGroup) {
+            $attributeGroup = $this->container->get('pim_catalog.factory.attribute_group')->create();
+            $this->container->get('pim_catalog.updater.attribute_group')->update($attributeGroup, [
+                'code' => 'other',
+            ]);
+            $this->container->get('pim_catalog.saver.attribute_group')->save($attributeGroup);
+        }
+
+        $attributeFactory = $this->container->get('pim_catalog.factory.attribute');
+        $attributeUpdater = $this->container->get('pim_catalog.updater.attribute');
+        $attributeSaver = $this->container->get('pim_catalog.saver.attribute');
+
+        $attributeRepo = $this->container->get('pim_catalog.repository.attribute');
+        $identifier = $attributeRepo->getIdentifier();
+        if (null === $identifier) {
+            $identifier = $attributeFactory->createAttribute(AttributeTypes::IDENTIFIER);
+            $attributeUpdater->update(
+                $identifier,
+                [
+                    'group' => 'other',
+                    'code'  => 'sku',
+                ]
+            );
+            $attributeSaver->save($identifier);
+        }
+
+        $textCollection = $attributeFactory->createAttribute(ExtendedAttributeTypes::TEXT_COLLECTION);
+        $attributeUpdater->update(
+            $textCollection,
+            [
+                'group' => 'other',
+                'code'  => 'my_images',
+            ]
+        );
+        $attributeSaver->save($textCollection);
+    }
+
+    /**
+     * @param string $identifier
+     * @param array $textCollection
+     */
+    protected function createProduct($identifier, $textCollection = [])
+    {
+        $product = $this->container->get('pim_catalog.builder.product')->createProduct($identifier);
+        $productData = ['my_images' => [['data' => $textCollection, 'locale' => null, 'scope' => null]]];
+        $this->container->get('pim_catalog.updater.product')->update($product, ['values' => $productData]);
+        $this->container->get('pim_catalog.saver.product')->save($product);
+
+        sleep(2);
+    }
+
+    protected function resetDB()
+    {
+        $productRepo = $this->container->get('pim_catalog.repository.product');
+        $productRemover = $this->container->get('pim_catalog.remover.product');
+        $products = $productRepo->findAll();
+        $productRemover->removeAll($products);
+
+        $attributeRepo = $this->container->get('pim_catalog.repository.attribute');
+        $attributeRemover = $this->container->get('pim_catalog.remover.attribute');
+        $textCollectionAttribute = $attributeRepo->findOneByIdentifier('my_images');
+        if ($textCollectionAttribute instanceof AttributeInterface) {
+            $attributeRemover->remove($textCollectionAttribute);
+        }
+    }
+}

--- a/Tests/Resources/Jenkins/config/parameters_test.yml
+++ b/Tests/Resources/Jenkins/config/parameters_test.yml
@@ -12,3 +12,6 @@ parameters:
     product_model_index_name: akeneo_pim_product_model
     product_and_product_model_index_name: akeneo_pim_product_and_product_model
     index_hosts: 'elastic:changeme@elasticsearch:9200'
+    elasticsearch_index_configuration_files:
+        - '%kernel.root_dir%/../vendor/akeneo/pim-community-dev/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml'
+        - '%kernel.root_dir%/../vendor/akeneo/extended-attribute-type/src/Resources/config/elasticsearch/index_configuration.yml'

--- a/Tests/Resources/Jenkins/config/parameters_test_ee.yml
+++ b/Tests/Resources/Jenkins/config/parameters_test_ee.yml
@@ -12,3 +12,8 @@ parameters:
     product_model_index_name: akeneo_pim_product_model
     product_and_product_model_index_name: akeneo_pim_product_and_product_model
     index_hosts: 'elastic:changeme@elasticsearch:9200'
+    elasticsearch_index_configuration_files:
+        - '%kernel.root_dir%/../vendor/akeneo/pim-community-dev/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml'
+        - '%kernel.root_dir%/../vendor/akeneo/pim-enterprise-dev/src/PimEnterprise/Bundle/WorkflowBundle/Resources/elasticsearch/index_configuration.yml'
+        - '%kernel.root_dir%/../vendor/akeneo/extended-attribute-type/src/Resources/config/elasticsearch/index_configuration.yml'
+        - '%kernel.root_dir%/../vendor/akeneo/extended-attribute-type/src/Resources/config/elasticsearch/index_configuration_ee.yml'

--- a/Tests/TextCollection/TextCollectionTest.php
+++ b/Tests/TextCollection/TextCollectionTest.php
@@ -54,6 +54,5 @@ class TextCollectionTest extends KernelTestCase
         $this->assertInstanceOf(AttributeInterface::class, $savedAttribute);
         $this->assertEquals(ExtendedAttributeTypes::TEXT_COLLECTION, $savedAttribute->getType());
         $this->assertEquals(ExtendedAttributeTypes::BACKEND_TYPE_TEXT_COLLECTION, $savedAttribute->getBackendType());
-//        $this->assertEquals($defaultGroup->getCode(), $savedAttribute->getGroup()->getCode());
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -27,12 +27,6 @@
             "Pim\\Bundle\\ExtendedAttributeTypeBundle\\": "src/"
         }
     },
-    "autoload-dev": {
-        "psr-4": {
-            "Pim\\Bundle\\ExtendedCeBundle\\": "doc/example/PimBundle/ExtendedCeBundle",
-            "Pim\\Bundle\\ExtendedEeBundle\\": "doc/example/PimBundle/ExtendedEeBundle"
-        }
-    },
     "extra": {
         "branch-alias": {
             "dev-1.0": "1.0.x-dev",

--- a/spec/Pim/Bundle/ExtendedAttributeTypeBundle/Elasticsearch/Filter/Attribute/TextCollectionFilterSpec.php
+++ b/spec/Pim/Bundle/ExtendedAttributeTypeBundle/Elasticsearch/Filter/Attribute/TextCollectionFilterSpec.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace spec\Pim\Bundle\ExtendedAttributeTypeBundle\Elasticsearch\Filter\Attribute;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\AbstractAttributeFilter;
+use Pim\Bundle\CatalogBundle\Elasticsearch\SearchQueryBuilder;
+use Pim\Bundle\ExtendedAttributeTypeBundle\AttributeType\ExtendedAttributeTypes;
+use Pim\Bundle\ExtendedAttributeTypeBundle\Elasticsearch\Filter\Attribute\TextCollectionFilter;
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Exception\InvalidOperatorException;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;
+use Pim\Component\Catalog\Query\Filter\Operators;
+use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
+use Prophecy\Argument;
+
+class TextCollectionFilterSpec extends ObjectBehavior
+{
+    function let(
+        AttributeValidatorHelper $attrValidatorHelper,
+        AttributeInterface $urlList
+    ) {
+        $this->beConstructedWith(
+            $attrValidatorHelper,
+            [ExtendedAttributeTypes::TEXT_COLLECTION],
+            [Operators::CONTAINS, Operators::DOES_NOT_CONTAIN, Operators::IS_EMPTY, Operators::IS_NOT_EMPTY]
+        );
+
+        $urlList->getType()->willReturn(ExtendedAttributeTypes::TEXT_COLLECTION);
+        $urlList->getBackendType()->willReturn(ExtendedAttributeTypes::BACKEND_TYPE_TEXT_COLLECTION);
+        $urlList->getCode()->willReturn('url_list');
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(TextCollectionFilter::class);
+    }
+
+    function it_is_a_filter()
+    {
+        $this->shouldImplement(AttributeFilterInterface::class);
+        $this->shouldBeAnInstanceOf(AbstractAttributeFilter::class);
+    }
+
+    function it_supports_operators()
+    {
+        $this->getOperators()->shouldReturn(
+            [
+                'CONTAINS',
+                'DOES NOT CONTAIN',
+                'EMPTY',
+                'NOT EMPTY',
+            ]
+        );
+        $this->supportsOperator('CONTAINS')->shouldReturn(true);
+        $this->supportsOperator('FAKE')->shouldReturn(false);
+    }
+
+    function it_supports_text_collection_attributes
+    (
+        AttributeInterface $urlList,
+        AttributeInterface $textAttribute
+    ) {
+        $this->getAttributeTypes()->shouldReturn([ExtendedAttributeTypes::TEXT_COLLECTION]);
+
+        $textAttribute->getType()->willReturn(AttributeTypes::TEXT);
+        $this->supportsAttribute($textAttribute)->shouldReturn(false);
+        $this->supportsAttribute($urlList)->shouldReturn(true);
+    }
+
+    function it_throws_an_exception_on_uninitialized_query_builder(AttributeInterface $urlList)
+    {
+        $this->shouldThrow(new \LogicException('The search query builder is not initialized in the filter.'))
+             ->during(
+                 'addAttributeFilter',
+                 [
+                     $urlList,
+                     Argument::any(),
+                     Argument::cetera(),
+                 ]
+             );
+    }
+
+    function it_throws_an_exception_on_unsupported_operator(
+        SearchQueryBuilder $searchQueryBuilder,
+        AttributeInterface $urlList
+    ) {
+        $this->setQueryBuilder($searchQueryBuilder);
+        $operator = Operators::STARTS_WITH;
+        $exception = InvalidOperatorException::notSupported($operator, TextCollectionFilter::class);
+        $this->shouldThrow($exception)->during(
+            'addAttributeFilter',
+            [
+                $urlList,
+                $operator,
+                'anystring',
+            ]
+        );
+    }
+
+    function it_adds_a_filter_with_operator_empty(
+        $attrValidatorHelper,
+        AttributeInterface $urlList,
+        SearchQueryBuilder $sqb
+    ) {
+        $attrValidatorHelper->validateLocale($urlList, 'en_US')->shouldBeCalled();
+        $attrValidatorHelper->validateScope($urlList, 'ecommerce')->shouldBeCalled();
+
+        $sqb->addMustNot(
+            [
+                'exists' => [
+                    'field' => 'values.url_list-textCollection.ecommerce.en_US',
+                ],
+            ]
+        )->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addAttributeFilter($urlList, Operators::IS_EMPTY, null, 'en_US', 'ecommerce', []);
+    }
+
+    function it_adds_a_filter_with_operator_is_not_empty(
+        $attrValidatorHelper,
+        AttributeInterface $urlList,
+        SearchQueryBuilder $sqb
+    ) {
+        $attrValidatorHelper->validateLocale($urlList, 'en_US')->shouldBeCalled();
+        $attrValidatorHelper->validateScope($urlList, 'ecommerce')->shouldBeCalled();
+
+        $sqb->addFilter(
+            [
+                'exists' => [
+                    'field' => 'values.url_list-textCollection.ecommerce.en_US',
+                ],
+            ]
+        )->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addAttributeFilter($urlList, Operators::IS_NOT_EMPTY, null, 'en_US', 'ecommerce', []);
+    }
+
+    function it_adds_a_filter_with_operator_contains(
+        $attrValidatorHelper,
+        AttributeInterface $urlList,
+        SearchQueryBuilder $sqb
+    ) {
+        $attrValidatorHelper->validateLocale($urlList, 'en_US')->shouldBeCalled();
+        $attrValidatorHelper->validateScope($urlList, 'ecommerce')->shouldBeCalled();
+
+        $sqb->addFilter(
+            [
+                'term' => [
+                    'values.url_list-textCollection.ecommerce.en_US' => 'http\:\/\/fake\-domain.null',
+                ],
+            ]
+        )->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addAttributeFilter($urlList, Operators::CONTAINS, 'http://fake-domain.null', 'en_US', 'ecommerce', []);
+    }
+
+    function it_adds_a_filter_with_operator_does_not_contain(
+        $attrValidatorHelper,
+        AttributeInterface $urlList,
+        SearchQueryBuilder $sqb
+    ) {
+        $attrValidatorHelper->validateLocale($urlList, 'en_US')->shouldBeCalled();
+        $attrValidatorHelper->validateScope($urlList, 'ecommerce')->shouldBeCalled();
+
+        $sqb->addFilter([
+                'exists' => [
+                    'field' => 'values.url_list-textCollection.ecommerce.en_US',
+                ],
+            ]
+        )->shouldBeCalled();
+
+        $sqb->addMustNot(
+            [
+                'term' => [
+                    'values.url_list-textCollection.ecommerce.en_US' => 'http\:\/\/fake\-domain.null',
+                ],
+            ]
+        )->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addAttributeFilter($urlList, Operators::DOES_NOT_CONTAIN, 'http://fake-domain.null', 'en_US', 'ecommerce', []);
+    }
+}

--- a/spec/Pim/Bundle/ExtendedAttributeTypeBundle/Elasticsearch/Filter/Attribute/TextCollectionFilterSpec.php
+++ b/spec/Pim/Bundle/ExtendedAttributeTypeBundle/Elasticsearch/Filter/Attribute/TextCollectionFilterSpec.php
@@ -150,7 +150,7 @@ class TextCollectionFilterSpec extends ObjectBehavior
         $sqb->addFilter(
             [
                 'term' => [
-                    'values.url_list-textCollection.ecommerce.en_US' => 'http\:\/\/fake\-domain.null',
+                    'values.url_list-textCollection.ecommerce.en_US' => 'http://fake-domain.null',
                 ],
             ]
         )->shouldBeCalled();
@@ -177,7 +177,7 @@ class TextCollectionFilterSpec extends ObjectBehavior
         $sqb->addMustNot(
             [
                 'term' => [
-                    'values.url_list-textCollection.ecommerce.en_US' => 'http\:\/\/fake\-domain.null',
+                    'values.url_list-textCollection.ecommerce.en_US' => 'http://fake-domain.null',
                 ],
             ]
         )->shouldBeCalled();

--- a/src/DataGrid/Form/Type/Filter/TextCollectionFilterType.php
+++ b/src/DataGrid/Form/Type/Filter/TextCollectionFilterType.php
@@ -17,7 +17,6 @@ class TextCollectionFilterType extends AbstractType
 {
     const TYPE_CONTAINS = 1;
     const TYPE_NOT_CONTAINS = 2;
-    const TYPE_EMPTY = 3;
 
     const NAME = 'pim_type_text_collection_filter';
 
@@ -54,9 +53,10 @@ class TextCollectionFilterType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $choices = [
-            self::TYPE_CONTAINS     => $this->translator->trans('oro.filter.form.label_type_contains'),
-            self::TYPE_NOT_CONTAINS => $this->translator->trans('oro.filter.form.label_type_not_contains'),
-            FilterType::TYPE_EMPTY  => $this->translator->trans('oro.filter.form.label_type_empty'),
+            self::TYPE_CONTAINS        => $this->translator->trans('oro.filter.form.label_type_contains'),
+            self::TYPE_NOT_CONTAINS    => $this->translator->trans('oro.filter.form.label_type_not_contains'),
+            FilterType::TYPE_EMPTY     => $this->translator->trans('oro.filter.form.label_type_empty'),
+            FilterType::TYPE_NOT_EMPTY => $this->translator->trans('oro.filter.form.label_type_not_empty'),
         ];
 
         $resolver->setDefaults(

--- a/src/Elasticsearch/Filter/Attribute/TextCollectionFilter.php
+++ b/src/Elasticsearch/Filter/Attribute/TextCollectionFilter.php
@@ -51,7 +51,6 @@ class TextCollectionFilter extends AbstractAttributeFilter implements AttributeF
 
         if (Operators::IS_EMPTY !== $operator && Operators::IS_NOT_EMPTY !== $operator) {
             $this->checkValue($attribute, $value);
-            $escapedValue = $this->escapeValue($value);
         }
 
         $attributePath = $this->getAttributePath($attribute, $locale, $channel);
@@ -60,7 +59,7 @@ class TextCollectionFilter extends AbstractAttributeFilter implements AttributeF
             case Operators::CONTAINS:
                 $clause = [
                     'term' => [
-                        $attributePath => $escapedValue,
+                        $attributePath => $value,
                     ],
                 ];
                 $this->searchQueryBuilder->addFilter($clause);
@@ -69,7 +68,7 @@ class TextCollectionFilter extends AbstractAttributeFilter implements AttributeF
             case Operators::DOES_NOT_CONTAIN:
                 $mustNotClause = [
                     'term' => [
-                        $attributePath => $escapedValue,
+                        $attributePath => $value,
                     ],
                 ];
                 $filterClause = [

--- a/src/Elasticsearch/Filter/Attribute/TextCollectionFilter.php
+++ b/src/Elasticsearch/Filter/Attribute/TextCollectionFilter.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Pim\Bundle\ExtendedAttributeTypeBundle\Elasticsearch\Filter\Attribute;
+
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
+use Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\AbstractAttributeFilter;
+use Pim\Component\Catalog\Exception\InvalidOperatorException;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;
+use Pim\Component\Catalog\Query\Filter\Operators;
+use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
+
+/**
+ * @author    Mathias METAYER <mathias.metayer@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class TextCollectionFilter extends AbstractAttributeFilter implements AttributeFilterInterface
+{
+    /**
+     * @param AttributeValidatorHelper $attrValidatorHelper
+     * @param array                    $supportedAttributeTypes
+     * @param array                    $supportedOperators
+     */
+    public function __construct(
+        AttributeValidatorHelper $attrValidatorHelper,
+        array $supportedAttributeTypes = [],
+        array $supportedOperators = []
+    ) {
+        $this->attrValidatorHelper = $attrValidatorHelper;
+        $this->supportedAttributeTypes = $supportedAttributeTypes;
+        $this->supportedOperators = $supportedOperators;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addAttributeFilter(
+        AttributeInterface $attribute,
+        $operator,
+        $value,
+        $locale = null,
+        $channel = null,
+        $options = []
+    ) {
+        if (null === $this->searchQueryBuilder) {
+            throw new \LogicException('The search query builder is not initialized in the filter.');
+        }
+
+        $this->checkLocaleAndChannel($attribute, $locale, $channel);
+
+        if (Operators::IS_EMPTY !== $operator && Operators::IS_NOT_EMPTY !== $operator) {
+            $this->checkValue($attribute, $value);
+            $escapedValue = $this->escapeValue($value);
+        }
+
+        $attributePath = $this->getAttributePath($attribute, $locale, $channel);
+
+        switch ($operator) {
+            case Operators::CONTAINS:
+                $clause = [
+                    'term' => [
+                        $attributePath => $escapedValue,
+                    ],
+                ];
+                $this->searchQueryBuilder->addFilter($clause);
+                break;
+
+            case Operators::DOES_NOT_CONTAIN:
+                $mustNotClause = [
+                    'term' => [
+                        $attributePath => $escapedValue,
+                    ],
+                ];
+                $filterClause = [
+                    'exists' => ['field' => $attributePath],
+                ];
+
+                $this->searchQueryBuilder->addMustNot($mustNotClause);
+                $this->searchQueryBuilder->addFilter($filterClause);
+                break;
+
+            case Operators::IS_EMPTY:
+                $clause = [
+                    'exists' => [
+                        'field' => $attributePath,
+                    ],
+                ];
+                $this->searchQueryBuilder->addMustNot($clause);
+                break;
+
+            case Operators::IS_NOT_EMPTY:
+                $clause = [
+                    'exists' => [
+                        'field' => $attributePath,
+                    ],
+                ];
+                $this->searchQueryBuilder->addFilter($clause);
+                break;
+
+            default:
+                throw InvalidOperatorException::notSupported($operator, static::class);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Check if the value is valid
+     *
+     * @param AttributeInterface $attribute
+     * @param mixed              $value
+     */
+    protected function checkValue(AttributeInterface $attribute, $value)
+    {
+        if (!is_string($value) && null !== $value) {
+            throw InvalidPropertyTypeException::stringExpected($attribute->getCode(), static::class, $value);
+        }
+    }
+}

--- a/src/Filter/ProductValue/TextCollectionFilter.php
+++ b/src/Filter/ProductValue/TextCollectionFilter.php
@@ -22,6 +22,7 @@ class TextCollectionFilter extends StringFilter
         TextFilterType::TYPE_CONTAINS     => Operators::CONTAINS,
         TextFilterType::TYPE_NOT_CONTAINS => Operators::DOES_NOT_CONTAIN,
         FilterType::TYPE_EMPTY            => Operators::IS_EMPTY,
+        FilterType::TYPE_NOT_EMPTY        => Operators::IS_NOT_EMPTY,
     ];
 
     /**

--- a/src/Model/TextCollectionValue.php
+++ b/src/Model/TextCollectionValue.php
@@ -46,9 +46,10 @@ class TextCollectionValue extends AbstractValue implements ValueInterface
      */
     public function removeItem(string $item)
     {
-        $this->data = array_filter($this->data, function ($value) use ($item) {
+        $data = array_filter($this->data, function ($value) use ($item) {
             return $value !== $item;
         });
+        $this->data = array_values($data);
     }
 
     /**

--- a/src/Model/TextCollectionValue.php
+++ b/src/Model/TextCollectionValue.php
@@ -46,10 +46,9 @@ class TextCollectionValue extends AbstractValue implements ValueInterface
      */
     public function removeItem(string $item)
     {
-        if ($index = array_search($item, $this->data, true)) {
-            unset($this->data[$index]);
-            $this->data = array_values($this->data);
-        }
+        $this->data = array_filter($this->data, function ($value) use ($item) {
+            return $value !== $item;
+        });
     }
 
     /**

--- a/src/Model/TextCollectionValue.php
+++ b/src/Model/TextCollectionValue.php
@@ -42,10 +42,21 @@ class TextCollectionValue extends AbstractValue implements ValueInterface
     }
 
     /**
+     * @param string $item
+     */
+    public function removeItem(string $item)
+    {
+        if ($index = array_search($item, $this->data, true)) {
+            unset($this->data[$index]);
+            $this->data = array_values($this->data);
+        }
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function __toString()
     {
-        return (string)$this->data;
+        return implode(', ', $this->data);
     }
 }

--- a/src/Resources/config/elasticsearch/index_configuration.yml
+++ b/src/Resources/config/elasticsearch/index_configuration.yml
@@ -14,3 +14,4 @@ mappings:
                     path_match: 'values.*-textCollection.*'
                     mapping:
                         type: 'keyword'
+                        index: 'not_analyzed'

--- a/src/Resources/config/elasticsearch/index_configuration_ee.yml
+++ b/src/Resources/config/elasticsearch/index_configuration_ee.yml
@@ -14,3 +14,4 @@ mappings:
                     path_match: 'values.*-textCollection.*'
                     mapping:
                         type: 'keyword'
+                        index: 'not_analyzed'

--- a/src/Resources/config/query_builders.yml
+++ b/src/Resources/config/query_builders.yml
@@ -1,5 +1,5 @@
 parameters:
-        pim_catalog.query.elasticsearch.filter.text_collection.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\TextFilter
+        pim_catalog.query.elasticsearch.filter.text_collection.class: Pim\Bundle\ExtendedAttributeTypeBundle\Elasticsearch\Filter\Attribute\TextCollectionFilter
 
 services:
     pim_catalog.query.elasticsearch.filter.text_collection:
@@ -7,6 +7,8 @@ services:
         arguments:
             - '@pim_catalog.validator.helper.attribute'
             - [!php/const:\Pim\Bundle\ExtendedAttributeTypeBundle\AttributeType\ExtendedAttributeTypes::TEXT_COLLECTION]
-            - ['STARTS WITH', 'CONTAINS', 'DOES NOT CONTAIN', '=', 'EMPTY', 'NOT EMPTY', '!=']
+            - ['CONTAINS', 'DOES NOT CONTAIN', 'EMPTY', 'NOT EMPTY']
         tags:
-            - { name: 'pim_catalog.elasticsearch.query.filter', priority: 30 }
+            - { name: 'pim_catalog.elasticsearch.query.product_filter', priority: 30 }
+            - { name: 'pim_catalog.elasticsearch.query.product_model_filter', priority: 30 }
+            - { name: 'pim_catalog.elasticsearch.query.product_and_product_model_filter', priority: 30 }

--- a/src/Resources/public/js/product/field/text-collection-field.js
+++ b/src/Resources/public/js/product/field/text-collection-field.js
@@ -63,12 +63,11 @@ define(
             },
 
             addRow() {
-                const newValue = this.$el.find('.AknTextCollection-newItem').val();
                 let values = [];
                 if (null !== this.getCurrentValue().data) {
                     values = this.getCurrentValue().data;
                 }
-                values.push($.trim(newValue));
+                values.push("");
                 this.setCurrentValue(values);
                 this.render();
                 this.setFocus();
@@ -76,12 +75,9 @@ define(
 
             updateModel() {
                 let values = [];
-                this.$('.field-input:first .AknTextCollection-items tbody tr').each(function () {
-                    const $row = $(this);
-                    const text = $row.find('.AknTextCollection-item').val();
-                    if ('' !== $.trim(text)) {
-                        values.push(text);
-                    }
+                this.$('.field-input:first .AknTextCollection-items tbody tr :input.AknTextCollection-item').each(function () {
+                    const text = $(this).val();
+                    values.push($.trim(text));
                 });
                 this.setCurrentValue(values);
             },

--- a/src/Resources/public/templates/product/field/text-collection.html
+++ b/src/Resources/public/templates/product/field/text-collection.html
@@ -25,12 +25,10 @@
         <% if (editMode !== 'view') { %>
         <tr>
             <td></td>
-            <td><input type="text"
-                       class="AknTextField AknTextCollection-newItem"
-            /></td>
-            <td class="AknTextCollection-actions"><button
-                    class="AknButton AknButton--small AknTextCollection-addButton"
-            >Add item</button></td>
+            <td></td>
+            <td class="AknTextCollection-actions">
+                <button class="AknButton AknButton--small AknTextCollection-addButton">Add item</button>
+            </td>
         </tr>
         <% } %>
         </tbody>

--- a/src/Validator/ConstraintGuesser/TextCollectionGuesser.php
+++ b/src/Validator/ConstraintGuesser/TextCollectionGuesser.php
@@ -5,6 +5,7 @@ namespace Pim\Bundle\ExtendedAttributeTypeBundle\Validator\ConstraintGuesser;
 use Pim\Bundle\ExtendedAttributeTypeBundle\AttributeType\ExtendedAttributeTypes;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Validator\ChainedAttributeConstraintGuesser;
+use Pim\Component\Catalog\Validator\ConstraintGuesser\NotBlankGuesser;
 use Pim\Component\Catalog\Validator\ConstraintGuesserInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -30,7 +31,6 @@ class TextCollectionGuesser implements ConstraintGuesserInterface
      */
     public function guessConstraints(AttributeInterface $attribute)
     {
-        $constraints = [];
         $guesser = new ChainedAttributeConstraintGuesser();
 
         if ('url' === $attribute->getValidationRule()) {
@@ -43,12 +43,11 @@ class TextCollectionGuesser implements ConstraintGuesserInterface
 
         $guesser->addConstraintGuesser(new LengthGuesser());
 
-        if (null !== $guesser) {
-            return [
-                new Assert\All(['constraints' => $guesser->guessConstraints($attribute)]),
-            ];
-        }
+        $constraints = $guesser->guessConstraints($attribute);
+        $constraints[] = new Assert\NotBlank();
 
-        return $constraints;
+        return [
+            new Assert\All(['constraints' => $constraints]),
+        ];
     }
 }


### PR DESCRIPTION
This PR adds an actual Elasticsearch AttributeFilter for TextCollection values, as the Pim's "TextFilter" previously used doesn't work for e.g collection of URI's (search on the grid didn't return anything)

# TODO:
- [x] Update documentation about elasticsearch indexes configuration, or update it automatically
- [x] Integration tests on pqb