### PR TITLE
[WIP] - PIM v3.0 compatibility

### DIFF
--- a/src/ArrayConverter/FlatToStandard/Product/ValueConverter/TextCollectionConverter.php
+++ b/src/ArrayConverter/FlatToStandard/Product/ValueConverter/TextCollectionConverter.php
@@ -2,8 +2,8 @@
 
 namespace Pim\Bundle\ExtendedAttributeTypeBundle\ArrayConverter\FlatToStandard\Product\ValueConverter;
 
+use Akeneo\Pim\Enrichment\Component\Product\Connector\ArrayConverter\FlatToStandard\ValueConverter\ValueConverterInterface;
 use Pim\Bundle\ExtendedAttributeTypeBundle\AttributeType\TextCollectionType;
-use Pim\Component\Connector\ArrayConverter\FlatToStandard\Product\ValueConverter\ValueConverterInterface;
 
 /**
  * Converts a text collection value from Akeneo PIM flat format to Akeneo PIM standard format

--- a/src/ArrayConverter/StandardToFlat/Product/ValueConverter/TextCollectionConverter.php
+++ b/src/ArrayConverter/StandardToFlat/Product/ValueConverter/TextCollectionConverter.php
@@ -3,8 +3,8 @@
 namespace Pim\Bundle\ExtendedAttributeTypeBundle\ArrayConverter\StandardToFlat\Product\ValueConverter;
 
 use Pim\Bundle\ExtendedAttributeTypeBundle\AttributeType\TextCollectionType;
-use Pim\Component\Connector\ArrayConverter\StandardToFlat\Product\ValueConverter\AbstractValueConverter;
-use Pim\Component\Connector\ArrayConverter\StandardToFlat\Product\ValueConverter\ValueConverterInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Connector\ArrayConverter\StandardToFlat\Product\ValueConverter\AbstractValueConverter;
+use Akeneo\Pim\Enrichment\Component\Product\Connector\ArrayConverter\StandardToFlat\Product\ValueConverter\ValueConverterInterface;
 
 /**
  * Converts a text collection value from Akeneo PIM standard format to Akeneo PIM flat format

--- a/src/AttributeType/ExtendedAttributeTypes.php
+++ b/src/AttributeType/ExtendedAttributeTypes.php
@@ -13,5 +13,5 @@ final class ExtendedAttributeTypes
 {
     const TEXT_COLLECTION = 'pim_catalog_text_collection';
 
-    const BACKEND_TYPE_TEXT_COLLECTION = 'textCollection';
+    const BACKEND_TYPE_TEXT_COLLECTION = 'text_collection';
 }

--- a/src/AttributeType/TextCollectionType.php
+++ b/src/AttributeType/TextCollectionType.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Bundle\ExtendedAttributeTypeBundle\AttributeType;
 
-use Pim\Bundle\CatalogBundle\AttributeType\AbstractAttributeType;
+use Akeneo\Pim\Structure\Component\AttributeType\AbstractAttributeType;
 
 /**
  * Text collection attribute type

--- a/src/Completeness/Checker/TextCollectionCompleteChecker.php
+++ b/src/Completeness/Checker/TextCollectionCompleteChecker.php
@@ -2,11 +2,12 @@
 
 namespace Pim\Bundle\ExtendedAttributeTypeBundle\Completeness\Checker;
 
+use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Pim\Bundle\ExtendedAttributeTypeBundle\AttributeType\ExtendedAttributeTypes;
-use Pim\Component\Catalog\Completeness\Checker\ValueCompleteCheckerInterface;
-use Pim\Component\Catalog\Model\ChannelInterface;
-use Pim\Component\Catalog\Model\LocaleInterface;
-use Pim\Component\Catalog\Model\ValueInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Completeness\Checker\ValueCompleteCheckerInterface;
+use Akeneo\Channel\Component\Model\ChannelInterface;
+use Akeneo\Channel\Component\Model\LocaleInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ValueInterface;
 
 /**
  * @author    JM Leroux <jean-marie.leroux@akeneo.com>
@@ -15,6 +16,17 @@ use Pim\Component\Catalog\Model\ValueInterface;
  */
 class TextCollectionCompleteChecker implements ValueCompleteCheckerInterface
 {
+    /** @var IdentifiableObjectRepositoryInterface */
+    private $attributeRepository;
+
+    /**
+     * @param IdentifiableObjectRepositoryInterface $attributeRepository
+     */
+    public function __construct(IdentifiableObjectRepositoryInterface $attributeRepository)
+    {
+        $this->attributeRepository = $attributeRepository;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -44,6 +56,8 @@ class TextCollectionCompleteChecker implements ValueCompleteCheckerInterface
         ChannelInterface $channel,
         LocaleInterface $locale
     ) {
-        return ExtendedAttributeTypes::TEXT_COLLECTION === $value->getAttribute()->getType();
+        $attribute = $this->attributeRepository->findOneByIdentifier($value->getAttributeCode());
+
+        return ExtendedAttributeTypes::TEXT_COLLECTION === $attribute->getType();
     }
 }

--- a/src/DependencyInjection/PimExtendedAttributeTypeExtension.php
+++ b/src/DependencyInjection/PimExtendedAttributeTypeExtension.php
@@ -35,7 +35,7 @@ class PimExtendedAttributeTypeExtension extends Extension
         $loader->load('entities.yml');
         $loader->load('factories.yml');
         $loader->load('query_builders.yml');
-        if (class_exists('PimEnterprise\Bundle\WorkflowBundle\PimEnterpriseWorkflowBundle')) {
+        if (class_exists('Akeneo\Pim\WorkOrganization\Workflow\Bundle\AkeneoPimWorkflowBundle')) {
             $loader->load('query_builders_ee.yml');
         }
 

--- a/src/Elasticsearch/Filter/Attribute/ProductProposalTextCollectionFilter.php
+++ b/src/Elasticsearch/Filter/Attribute/ProductProposalTextCollectionFilter.php
@@ -2,13 +2,13 @@
 
 namespace Pim\Bundle\ExtendedAttributeTypeBundle\Elasticsearch\Filter\Attribute;
 
-use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
-use Pim\Component\Catalog\Exception\InvalidOperatorException;
-use Pim\Component\Catalog\Model\AttributeInterface;
-use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;
-use Pim\Component\Catalog\Query\Filter\Operators;
-use PimEnterprise\Bundle\WorkflowBundle\Elasticsearch\Filter\Attribute\AbstractAttributeFilter;
-use PimEnterprise\Bundle\WorkflowBundle\Elasticsearch\Filter\Attribute\ProposalAttributePathResolver;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidOperatorException;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\AttributeFilterInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\WorkOrganization\Workflow\Bundle\Elasticsearch\Filter\Attribute\AbstractAttributeFilter;
+use Akeneo\Pim\WorkOrganization\Workflow\Bundle\Elasticsearch\Filter\Attribute\ProposalAttributePathResolver;
 
 /**
  * @author    Mathias METAYER <mathias.metayer@akeneo.com>

--- a/src/Elasticsearch/Filter/Attribute/TextCollectionFilter.php
+++ b/src/Elasticsearch/Filter/Attribute/TextCollectionFilter.php
@@ -2,13 +2,13 @@
 
 namespace Pim\Bundle\ExtendedAttributeTypeBundle\Elasticsearch\Filter\Attribute;
 
-use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
-use Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\AbstractAttributeFilter;
-use Pim\Component\Catalog\Exception\InvalidOperatorException;
-use Pim\Component\Catalog\Model\AttributeInterface;
-use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;
-use Pim\Component\Catalog\Query\Filter\Operators;
-use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute\AbstractAttributeFilter;
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidOperatorException;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\AttributeFilterInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\AttributeValidatorHelper;
 
 /**
  * @author    Mathias METAYER <mathias.metayer@akeneo.com>
@@ -58,8 +58,8 @@ class TextCollectionFilter extends AbstractAttributeFilter implements AttributeF
         switch ($operator) {
             case Operators::CONTAINS:
                 $clause = [
-                    'term' => [
-                        $attributePath => $value,
+                    'wildcard' => [
+                        $attributePath => '*' . $value . '*',
                     ],
                 ];
                 $this->searchQueryBuilder->addFilter($clause);
@@ -67,8 +67,8 @@ class TextCollectionFilter extends AbstractAttributeFilter implements AttributeF
 
             case Operators::DOES_NOT_CONTAIN:
                 $mustNotClause = [
-                    'term' => [
-                        $attributePath => $value,
+                    'wildcard' => [
+                        $attributePath => '*' . $value . '*',
                     ],
                 ];
                 $filterClause = [

--- a/src/Factory/Value/TextCollectionValueFactory.php
+++ b/src/Factory/Value/TextCollectionValueFactory.php
@@ -2,10 +2,12 @@
 
 namespace Pim\Bundle\ExtendedAttributeTypeBundle\Factory\Value;
 
-use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
-use Pim\Component\Catalog\AttributeTypes;
-use Pim\Component\Catalog\Factory\Value\ValueFactoryInterface;
-use Pim\Component\Catalog\Model\AttributeInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Factory\Value\AbstractValueFactory;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ValueInterface;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
+use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Pim\Enrichment\Component\Product\Factory\Value\ValueFactoryInterface;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 
 /**
  * Factory that creates simple product values (text, textarea and number).
@@ -14,7 +16,7 @@ use Pim\Component\Catalog\Model\AttributeInterface;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class TextCollectionValueFactory implements ValueFactoryInterface
+class TextCollectionValueFactory extends AbstractValueFactory implements ValueFactoryInterface
 {
     /** @var string */
     protected $productValueClass;
@@ -23,49 +25,14 @@ class TextCollectionValueFactory implements ValueFactoryInterface
     protected $supportedAttributeTypes;
 
     /**
-     * @param string $productValueClass
-     * @param string $supportedAttributeTypes
-     */
-    public function __construct($productValueClass, $supportedAttributeTypes)
-    {
-        $this->productValueClass = $productValueClass;
-        $this->supportedAttributeTypes = $supportedAttributeTypes;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function create(AttributeInterface $attribute, $channelCode, $localeCode, $data)
-    {
-        $this->checkData($attribute, $data);
-
-        if (null !== $data) {
-            $data = $this->convertData($attribute, $data);
-        }
-
-        $value = new $this->productValueClass($attribute, $channelCode, $localeCode, $data);
-
-        return $value;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function supports($attributeType)
-    {
-        return $attributeType === $this->supportedAttributeTypes;
-    }
-
-    /**
      * @param AttributeInterface $attribute
-     * @param mixed              $data
-     *
-     * @throws InvalidPropertyTypeException
+     * @param $data
+     * @param bool $ignoreUnknownData
      */
-    protected function checkData(AttributeInterface $attribute, $data)
+    protected function prepareData(AttributeInterface $attribute, $data, bool $ignoreUnknownData)
     {
         if (null === $data) {
-            return;
+            return [];
         }
 
         if (!is_array($data)) {
@@ -75,24 +42,16 @@ class TextCollectionValueFactory implements ValueFactoryInterface
                 $data
             );
         }
-    }
 
-    /**
-     * @param AttributeInterface $attribute
-     * @param mixed              $data
-     *
-     * @return mixed
-     */
-    protected function convertData(AttributeInterface $attribute, $data)
-    {
-        if (is_string($data) && '' === trim($data)) {
-            $data = null;
-        }
-
-        if (AttributeTypes::BOOLEAN === $attribute->getType() &&
-            (1 === $data || '1' === $data || 0 === $data || '0' === $data)
-        ) {
-            $data = boolval($data);
+        foreach ($data as $value) {
+            if (!is_string($value)) {
+                throw InvalidPropertyTypeException::validArrayStructureExpected(
+                    $attribute->getCode(),
+                    sprintf('one of the options is not a string, "%s" given', gettype($value)),
+                    static::class,
+                    $data
+                );
+            }
         }
 
         return $data;

--- a/src/Filter/FilterProvider.php
+++ b/src/Filter/FilterProvider.php
@@ -2,9 +2,9 @@
 
 namespace Pim\Bundle\ExtendedAttributeTypeBundle\Filter;
 
-use Pim\Bundle\EnrichBundle\Provider\Filter\FilterProviderInterface;
+use Akeneo\Platform\Bundle\UIBundle\Provider\Filter\FilterProviderInterface;
 use Pim\Bundle\ExtendedAttributeTypeBundle\AttributeType\ExtendedAttributeTypes;
-use Pim\Component\Catalog\Model\AttributeInterface;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 
 /**
  * Filter provider for text collection attribute

--- a/src/Filter/ProductValue/TextCollectionFilter.php
+++ b/src/Filter/ProductValue/TextCollectionFilter.php
@@ -5,8 +5,8 @@ namespace Pim\Bundle\ExtendedAttributeTypeBundle\Filter\ProductValue;
 use Oro\Bundle\FilterBundle\Form\Type\Filter\FilterType;
 use Oro\Bundle\FilterBundle\Form\Type\Filter\TextFilterType;
 use Pim\Bundle\ExtendedAttributeTypeBundle\DataGrid\Form\Type\Filter\TextCollectionFilterType;
-use Pim\Bundle\FilterBundle\Filter\ProductValue\StringFilter;
-use Pim\Component\Catalog\Query\Filter\Operators;
+use Oro\Bundle\PimFilterBundle\Filter\ProductValue\StringFilter;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 
 /**
  * TextCollectionFilter

--- a/src/Model/TextCollectionValue.php
+++ b/src/Model/TextCollectionValue.php
@@ -2,9 +2,9 @@
 
 namespace Pim\Bundle\ExtendedAttributeTypeBundle\Model;
 
-use Pim\Component\Catalog\Model\AbstractValue;
-use Pim\Component\Catalog\Model\AttributeInterface;
-use Pim\Component\Catalog\Model\ValueInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Model\AbstractValue;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ValueInterface;
 
 /**
  * Product value for TextCollection atribute type
@@ -19,22 +19,18 @@ class TextCollectionValue extends AbstractValue implements ValueInterface
     protected $data;
 
     /**
-     * @param AttributeInterface $attribute
-     * @param string             $channel
-     * @param string             $locale
-     * @param mixed              $data
+     * @param string $attributeCode
+     * @param ?string[] $data
+     * @param string|null $scopeCode
+     * @param string|null $localeCode
      */
-    public function __construct(AttributeInterface $attribute, $channel, $locale, $data)
+    protected function __construct(string $attributeCode, ?array $data, ?string $scopeCode, ?string $localeCode)
     {
-        $this->setAttribute($attribute);
-        $this->setScope($channel);
-        $this->setLocale($locale);
-
-        $this->data = $data;
+        parent::__construct($attributeCode, $data, $scopeCode, $localeCode);
     }
 
     /**
-     * @return string[]
+     * @return mixed|string[]
      */
     public function getData()
     {
@@ -52,10 +48,25 @@ class TextCollectionValue extends AbstractValue implements ValueInterface
         $this->data = array_values($data);
     }
 
+    public function isEqual(ValueInterface $value): bool
+    {
+        if (!$value instanceof TextCollectionValue ||
+            $this->getScopeCode() !== $value->getScopeCode() ||
+            $this->getLocaleCode() !== $value->getLocaleCode()) {
+            return false;
+        }
+
+        $comparedAttributeOptions = $value->getData();
+        $thisAttributeOptions = $this->getData();
+
+        return count(array_diff($thisAttributeOptions, $comparedAttributeOptions)) === 0 &&
+            count(array_diff($comparedAttributeOptions, $thisAttributeOptions)) === 0;
+    }
+
     /**
      * {@inheritdoc}
      */
-    public function __toString()
+    public function __toString(): string
     {
         return implode(', ', $this->data);
     }

--- a/src/Normalizer/Indexing/Value/TextCollectionNormalizer.php
+++ b/src/Normalizer/Indexing/Value/TextCollectionNormalizer.php
@@ -2,12 +2,13 @@
 
 namespace Pim\Bundle\ExtendedAttributeTypeBundle\Normalizer\Indexing\Value;
 
+use Akeneo\Pim\Enrichment\Component\Product\Normalizer\Indexing\ProductModel\ProductModelNormalizer;
 use Pim\Bundle\ExtendedAttributeTypeBundle\Model\TextCollectionValue;
-use Pim\Component\Catalog\Model\ValueInterface;
-use Pim\Component\Catalog\Normalizer\Indexing\Product\ProductNormalizer;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ValueInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Normalizer\Indexing\Product\ProductNormalizer;
 use Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel;
 use Pim\Component\Catalog\Normalizer\Indexing\ProductModel;
-use Pim\Component\Catalog\Normalizer\Indexing\Value\AbstractProductValueNormalizer;
+use Akeneo\Pim\Enrichment\Component\Product\Normalizer\Indexing\Value\AbstractProductValueNormalizer;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -26,8 +27,8 @@ class TextCollectionNormalizer extends AbstractProductValueNormalizer implements
     {
         return $data instanceof TextCollectionValue && (
                 $format === ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX ||
-                $format === ProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX ||
-                $format === ProductAndProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX
+                $format === ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX ||
+                $format === \Akeneo\Pim\Enrichment\Component\Product\Normalizer\Indexing\ProductAndProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX
             );
     }
 

--- a/src/PimExtendedAttributeTypeBundle.php
+++ b/src/PimExtendedAttributeTypeBundle.php
@@ -13,13 +13,4 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class PimExtendedAttributeTypeBundle extends Bundle
 {
-    public function boot()
-    {
-        parent::boot();
-
-        $registeredBundles = $this->container->getParameter('kernel.bundles');
-        if (array_key_exists('PimElasticSearchBundle', $registeredBundles)) {
-            ProductQueryUtility::addTypeSuffix(ExtendedAttributeTypes::TEXT_COLLECTION, ProductQueryUtility::SUFFIX_TEXT);
-        }
-    }
 }

--- a/src/Provider/Field/TextCollectionProvider.php
+++ b/src/Provider/Field/TextCollectionProvider.php
@@ -2,9 +2,9 @@
 
 namespace Pim\Bundle\ExtendedAttributeTypeBundle\Provider\Field;
 
-use Pim\Bundle\EnrichBundle\Provider\Field\FieldProviderInterface;
+use Akeneo\Platform\Bundle\UIBundle\Provider\Field\FieldProviderInterface;
 use Pim\Bundle\ExtendedAttributeTypeBundle\AttributeType\ExtendedAttributeTypes;
-use Pim\Component\Catalog\Model\AttributeInterface;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 
 class TextCollectionProvider implements FieldProviderInterface
 {

--- a/src/Resources/config/attribute_types.yml
+++ b/src/Resources/config/attribute_types.yml
@@ -6,8 +6,6 @@ services:
     pim_extended_attribute_type.attribute_type.text_collection:
         class: '%pim_extended_attribute_type.attribute_type.text_collection.class%'
         arguments:
-            - textCollection
-            - text
-            - '@pim_catalog.validator.constraint_guesser.chained_attribute'
+            - 'text_collection'
         tags:
             - { name: pim_catalog.attribute_type, alias: pim_catalog_text_collection }

--- a/src/Resources/config/completeness.yml
+++ b/src/Resources/config/completeness.yml
@@ -4,5 +4,7 @@ parameters:
 services:
     pim_extended_attribute_type.completeness.checker.text_collection:
         class: '%pim_extended_attribute_type.completeness.checker.text_collection.class%'
+        arguments:
+            - '@pim_catalog.repository.cached_attribute'
         tags:
             - { name: pim_catalog.completeness.checker.product_value, priority: 100 }

--- a/src/Resources/config/denormalizers.yml
+++ b/src/Resources/config/denormalizers.yml
@@ -13,5 +13,7 @@ services:
 
     pim_extended_attribute_type.normalizer.indexing_product.product.text_collection:
         class: '%pim_extended_attribute_type.normalizer.indexing_product.product.text_collection.class%'
+        arguments:
+            - '@pim_catalog.repository.attribute'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_indexing_serializer.normalizer, priority: 90 }

--- a/src/Resources/config/elasticsearch/index_configuration.yml
+++ b/src/Resources/config/elasticsearch/index_configuration.yml
@@ -5,13 +5,12 @@ mappings:
         dynamic_templates:
             -
                 text_collection_scopable_localizable_structure:
-                    path_match: 'values.*-textCollection.*'
+                    path_match: 'values.*-text_collection.*'
                     match_mapping_type: 'object'
                     mapping:
                         type: 'object'
             -
                 text_collection:
-                    path_match: 'values.*-textCollection.*'
+                    path_match: 'values.*-text_collection.*'
                     mapping:
                         type: 'keyword'
-                        index: 'not_analyzed'

--- a/src/Resources/translations/jsmessages.en.yml
+++ b/src/Resources/translations/jsmessages.en.yml
@@ -1,3 +1,3 @@
 pim_catalog_text_collection: Text Collection
 
-pim_enrich.entity.attribute.type.pim_catalog_text_collection: Text Collection
+pim_enrich.entity.attribute.property.type.pim_catalog_text_collection: Text Collection

--- a/src/Updater/Comparator/TextCollectionComparator.php
+++ b/src/Updater/Comparator/TextCollectionComparator.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Bundle\ExtendedAttributeTypeBundle\Updater\Comparator;
 
-use Pim\Component\Catalog\Comparator\ComparatorInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Comparator\ComparatorInterface;
 
 /**
  * Comparator which calculate change set for text collection

--- a/src/Validator/ConstraintGuesser/EmailGuesser.php
+++ b/src/Validator/ConstraintGuesser/EmailGuesser.php
@@ -3,8 +3,8 @@
 namespace Pim\Bundle\ExtendedAttributeTypeBundle\Validator\ConstraintGuesser;
 
 use Pim\Bundle\ExtendedAttributeTypeBundle\AttributeType\ExtendedAttributeTypes;
-use Pim\Component\Catalog\Model\AttributeInterface;
-use Pim\Component\Catalog\Validator\ConstraintGuesser\EmailGuesser as PimEmailGuesser;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\ConstraintGuesser\EmailGuesser as PimEmailGuesser;
 
 /**
  * Guesser

--- a/src/Validator/ConstraintGuesser/LengthGuesser.php
+++ b/src/Validator/ConstraintGuesser/LengthGuesser.php
@@ -3,8 +3,8 @@
 namespace Pim\Bundle\ExtendedAttributeTypeBundle\Validator\ConstraintGuesser;
 
 use Pim\Bundle\ExtendedAttributeTypeBundle\AttributeType\ExtendedAttributeTypes;
-use Pim\Component\Catalog\Model\AttributeInterface;
-use Pim\Component\Catalog\Validator\ConstraintGuesser\LengthGuesser as PimLengthGuesser;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\ConstraintGuesser\LengthGuesser as PimLengthGuesser;
 
 /**
  * Length guesser

--- a/src/Validator/ConstraintGuesser/RegexGuesser.php
+++ b/src/Validator/ConstraintGuesser/RegexGuesser.php
@@ -3,8 +3,8 @@
 namespace Pim\Bundle\ExtendedAttributeTypeBundle\Validator\ConstraintGuesser;
 
 use Pim\Bundle\ExtendedAttributeTypeBundle\AttributeType\ExtendedAttributeTypes;
-use Pim\Component\Catalog\Model\AttributeInterface;
-use Pim\Component\Catalog\Validator\ConstraintGuesser\RegexGuesser as PimRegexGuesser;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\ConstraintGuesser\RegexGuesser as PimRegexGuesser;
 
 /**
  * Regex guesser

--- a/src/Validator/ConstraintGuesser/TextCollectionGuesser.php
+++ b/src/Validator/ConstraintGuesser/TextCollectionGuesser.php
@@ -3,9 +3,9 @@
 namespace Pim\Bundle\ExtendedAttributeTypeBundle\Validator\ConstraintGuesser;
 
 use Pim\Bundle\ExtendedAttributeTypeBundle\AttributeType\ExtendedAttributeTypes;
-use Pim\Component\Catalog\Model\AttributeInterface;
-use Pim\Component\Catalog\Validator\ChainedAttributeConstraintGuesser;
-use Pim\Component\Catalog\Validator\ConstraintGuesserInterface;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\ChainedAttributeConstraintGuesser;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\ConstraintGuesserInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**

--- a/src/Validator/ConstraintGuesser/UrlGuesser.php
+++ b/src/Validator/ConstraintGuesser/UrlGuesser.php
@@ -3,8 +3,8 @@
 namespace Pim\Bundle\ExtendedAttributeTypeBundle\Validator\ConstraintGuesser;
 
 use Pim\Bundle\ExtendedAttributeTypeBundle\AttributeType\ExtendedAttributeTypes;
-use Pim\Component\Catalog\Model\AttributeInterface;
-use Pim\Component\Catalog\Validator\ConstraintGuesser\UrlGuesser as PimUrlGuesser;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\ConstraintGuesser\UrlGuesser as PimUrlGuesser;
 
 /**
  * Url guesser


### PR DESCRIPTION
### TODO:
- [ ] : update composer.json
- [ ] : update indexes for published product and product_proposal (EE); basically that means splitting the `index_configuration_ee.yml` file in two
- [ ] : Fix/Update the `ProductProposalTextCollectionFilter` accordingly
- [ ] : fix tests
- [ ] : update README (installation/upgrade)

### Breaking changes
`ExtendedAttributeTypes::BACKEND_TYPE_TEXT_COLLECTION` was renamed from `textCollection` to `text_collection` (I couldn't make it work with the former value, probably because of ES version)
